### PR TITLE
chore: auto-debug on development builds

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,9 +26,11 @@ jetbrains-annotations = "26.0.2"
 jspecify = "1.0.0"
 log4j = "2.25.3"
 mixinextras = "0.5.0"
+buildtimeconstants = "2.1.0"
 
 [plugins]
 architectury-loom = { id = "dev.architectury.loom", version.ref = "architectury-loom" }
+buildtimeconstants = { id = "name.remal.build-time-constants", version.ref = "buildtimeconstants" }
 
 [libraries]
 error_prone_annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "error_prone_annotations" }

--- a/src/main/java/ru/vidtu/hcscr/platform/HCompile.java
+++ b/src/main/java/ru/vidtu/hcscr/platform/HCompile.java
@@ -23,6 +23,7 @@
 package ru.vidtu.hcscr.platform;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
+import name.remal.gradle_plugins.build_time_constants.api.BuildTimeConstants;
 import net.minecraft.util.profiling.ProfilerFiller;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -41,7 +42,7 @@ public final class HCompile {
      * Whether the debug features are enabled.
      */
     @CompileTimeConstant
-    private static final boolean DEBUG = true;
+    private static final boolean DEBUG = BuildTimeConstants.getBooleanProperty("debug");
 
     /**
      * Whether the additional Java assertions are enabled.


### PR DESCRIPTION
This commit achieves automatic debug feature enablement on `runClient` and `runServer` (BRUH) tasks. Additionally, a build can manually be built with the debug constant set to true by passing `-Pdebug=true` to the Gradle invocation.